### PR TITLE
update_repo must use os.chdir().  calling os.system(cd

### DIFF
--- a/github-backup.py
+++ b/github-backup.py
@@ -71,7 +71,8 @@ def clone_repo(repo, dir, args):
 
 
 def update_repo(repo, dir, args):
-      os.system("cd %s"%(dir,))
+      savedPath = os.getcwd()
+      os.chdir(dir)
 
       # GitHub => Local
       if args.mirror:
@@ -80,6 +81,7 @@ def update_repo(repo, dir, args):
       else:
          os.system("git pull %s"%(args.git,))
 
+      os.chdir(savedPath)
 
 if __name__ == "__main__":
    main()


### PR DESCRIPTION
You probably want this change if you want update to work on linux.  Without this change, I see alot of:

fatal: Not a git repository (or any parent up to mount parent )
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).

This is because my cwd is not a git repo, and the system(cd <next git repo>) doesn't persist.
