### PR TITLE
add support for OAuth tokens

### DIFF
--- a/github-backup.py
+++ b/github-backup.py
@@ -27,6 +27,12 @@ def main():
 		config['password'] = args.password
 		config['login'] = args.username
 
+	# if both password and token are specified, the token will be
+	# used, according to pygithub3 sources
+	# however, the username isn't required when using a token
+	if (args.token):
+		config['token'] = args.token
+
 	gh = Github(**config)
 
 	# Get all of the given user's repos
@@ -57,6 +63,7 @@ def init_parser():
 	parser.add_argument("-P","--prefix", help="Add prefix to repository directory names", default="")
 	parser.add_argument("-o","--organization", help="Backup Organizational repositories")
 	parser.add_argument("-S","--ssh", help="Use SSH protocol", action="store_true")
+	parser.add_argument("-t","--token", help="Authenticate with Github API using OAuth token", default="")
 
 	return parser
 


### PR DESCRIPTION
Hi,

Added support for GitHub OAuth tokens. Works for me, even though I don't know any Python

In Perl when using Net::Github I noticed that
1. authentication via OAuth does not require specification of a username, and
2. the Github API can be used to find out the username after authentication

So maybe there is more that can be done here

Thanks for sharing!

John
