### PR TITLE
Fixes 'NoneType' object has no attribute 'replace'

### DIFF
--- a/github-backup.py
+++ b/github-backup.py
@@ -115,7 +115,8 @@ def update_repo(repo, dir, args):
 	os.chdir(savedPath)
 
 def shell_escape(str):
-	return "'" + unicode(str.replace("'", "\\'")).encode("utf-8") + "'"
+	if str:
+		return "'" + unicode(str.replace("'", "\\'")).encode("utf-8") + "'"
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
Kept getting the following error for a particular repository, not sure of the exact error, but this change fixed it.

    Traceback (most recent call last):
      File "./github-backup.py", line 121, in <module>
        main()
      File "./github-backup.py", line 46, in main
        process_repo(repo, args)
      File "./github-backup.py", line 83, in process_repo
        update_repo(repo, dir, args)
      File "./github-backup.py", line 108, in update_repo
        os.system("git config --local gitweb.description %s"%(shell_escape(repo.description),))
      File "./github-backup.py", line 118, in shell_escape
        return "'" + unicode(str.replace("'", "\\'")).encode("utf-8") + "'"
    AttributeError: 'NoneType' object has no attribute 'replace'

Not at all a python dev, so forgive me if this isn't the best way to resolve the issue :)