### PR TITLE
Big update

### DIFF
--- a/github-backup.py
+++ b/github-backup.py
@@ -230,23 +230,23 @@ def process_account(gh, account, args):
             json_dump(list(account.get_emails()), f)
 
     if args.include_starred:
-        LOGGER.debug("    Getting starred repository list")
+        LOGGER.info("    Getting starred repository list")
         fetch_url(account.starred_url, os.path.join(dir, 'starred.json'))
 
     if args.include_watched:
-        LOGGER.debug("    Getting watched repository list")
+        LOGGER.info("    Getting watched repository list")
         fetch_url(account.subscriptions_url, os.path.join(dir, 'watched.json'))
 
     if args.include_followers:
-        LOGGER.debug("    Getting followers repository list")
+        LOGGER.info("    Getting followers repository list")
         fetch_url(account.followers_url, os.path.join(dir, 'followers.json'))
 
     if args.include_following:
-        LOGGER.debug("    Getting following repository list")
+        LOGGER.info("    Getting following repository list")
         fetch_url(account.following_url, os.path.join(dir, 'following.json'))
 
     if args.include_issues:
-        LOGGER.debug("    Getting issues for user %s", account.login)
+        LOGGER.info("    Getting issues for user %s", account.login)
         if IsAuthorized:
             issues = account.get_issues()
         else:
@@ -255,7 +255,7 @@ def process_account(gh, account, args):
         RepositoryBackup._backup_issues(issues, args, dir)
 
     if args.include_pulls:
-        LOGGER.debug("    Getting pull requests for user %s", account.login)
+        LOGGER.info("    Getting pull requests for user %s", account.login)
         if IsAuthorized:
             issues = account.get_issues()
         else:
@@ -329,11 +329,11 @@ class RepositoryBackup(object):
                 self._backup_releases()
 
             if self.args.include_issues:
-                LOGGER.debug("    Getting issues for repo %s", self.repo.name)
+                LOGGER.info("    Getting issues for repo %s", self.repo.name)
                 self._backup_issues(self.repo.get_issues(), self.args, os.path.dirname(self.dir))
 
             if self.args.include_pulls:
-                LOGGER.debug("    Getting pull requests for repo %s", self.repo.name)
+                LOGGER.info("    Getting pull requests for repo %s", self.repo.name)
                 self._backup_pulls(self.repo.get_pulls(), self.args, os.path.dirname(self.dir))
 
     def clone_repo(self, url, dir):
@@ -375,7 +375,7 @@ class RepositoryBackup(object):
     def _backup_issues(cls, issues, args, dir):
         for issue in issues:
             issue_data = issue.raw_data.copy()
-            LOGGER.debug("     * %s", issue.number)
+            LOGGER.info("     * %s", issue.number)
             if args.include_issue_comments and issue.comments:
                 for comment in issue.get_comments():
                     issue_data.setdefault('comment_data', []).append(comment.raw_data)
@@ -396,7 +396,7 @@ class RepositoryBackup(object):
             if isinstance(issue, github.Issue.Issue):
                 issue = issue.as_pull_request()
             issue_data = issue.raw_data.copy()
-            LOGGER.debug("     * %s", issue.number)
+            LOGGER.info("     * %s", issue.number)
             if args.include_pull_comments and issue.comments:
                 for comment in issue.get_comments():
                     issue_data.setdefault('comment_data', []).append(comment.raw_data)

--- a/github-backup.py
+++ b/github-backup.py
@@ -404,7 +404,14 @@ class RepositoryBackup(object):
         for issue in issues:
             project = os.path.basename(os.path.dirname(os.path.dirname(issue.url)))
             if isinstance(issue, github.Issue.Issue):
-                issue = issue.as_pull_request()
+                try:
+                    if issue.pull_request:
+                        issue = issue.as_pull_request()
+                    else:
+                        continue
+                except github.UnknownObjectException, e:
+                    LOGGER.info("     * %s[%s]: No associated pull request", project, issue.number)
+                    continue
             issue_data = issue.raw_data.copy()
             LOGGER.info("     * %s[%s]: %s", project, issue.number, issue.title)
             if args.include_pull_comments and issue.comments:

--- a/github-backup.py
+++ b/github-backup.py
@@ -246,7 +246,9 @@ def fetch_url(url, outfile):
         "User-Agent": "PyGithub/Python"
     }
     with open(outfile, 'w') as f:
-        f.write(requests.get(url, headers=headers).content)
+        resp = requests.get(url, headers=headers)
+        LOGGER.debug("GET %s %r ==> %d %r", url, headers, resp.status_code, resp.headers)
+        f.write(resp.content.decode(resp.encoding or 'utf-8'))
 
 def process_account(gh, account, args):
     LOGGER.info("Processing account: %s", account.login)

--- a/github-backup.py
+++ b/github-backup.py
@@ -374,8 +374,9 @@ class RepositoryBackup(object):
     @classmethod
     def _backup_issues(cls, issues, args, dir):
         for issue in issues:
+            project = os.path.basename(os.path.dirname(os.path.dirname(issue.url)))
             issue_data = issue.raw_data.copy()
-            LOGGER.info("     * %s", issue.number)
+            LOGGER.info("     * %s[%s]: %s", project, issue.number, issue.title)
             if args.include_issue_comments and issue.comments:
                 for comment in issue.get_comments():
                     issue_data.setdefault('comment_data', []).append(comment.raw_data)
@@ -383,7 +384,6 @@ class RepositoryBackup(object):
                 for event in issue.get_events():
                     issue_data.setdefault('event_data', []).append(event.raw_data)
 
-            project = os.path.basename(os.path.dirname(os.path.dirname(issue.url)))
             issue_file = os.path.join(dir, 'issues', "{0}:{1}.json".format(project, issue.number))
             if not os.access(os.path.dirname(issue_file), os.F_OK):
                 mkdir_p(os.path.dirname(issue_file))
@@ -393,10 +393,11 @@ class RepositoryBackup(object):
     @classmethod
     def _backup_pulls(cls, issues, args, dir):
         for issue in issues:
+            project = os.path.basename(os.path.dirname(os.path.dirname(issue.url)))
             if isinstance(issue, github.Issue.Issue):
                 issue = issue.as_pull_request()
             issue_data = issue.raw_data.copy()
-            LOGGER.info("     * %s", issue.number)
+            LOGGER.info("     * %s[%s]: %s", project, issue.number, issue.title)
             if args.include_pull_comments and issue.comments:
                 for comment in issue.get_comments():
                     issue_data.setdefault('comment_data', []).append(comment.raw_data)
@@ -404,7 +405,6 @@ class RepositoryBackup(object):
                 for commit in issue.get_commits():
                     issue_data.setdefault('commit_data', []).append(commit.raw_data)
 
-            project = os.path.basename(os.path.dirname(os.path.dirname(issue.url)))
             issue_file = os.path.join(dir, 'pull-requests', "{0}:{1}.json".format(project, issue.number))
             if not os.access(os.path.dirname(issue_file), os.F_OK):
                 mkdir_p(os.path.dirname(issue_file))

--- a/github-backup.py
+++ b/github-backup.py
@@ -27,11 +27,11 @@ import github
 
 LOGGER = logging.getLogger('github-backup')
 
-IsAuthorized = False
+IS_AUTHORIZED = False
 CONFFILE = os.path.join(os.getenv('HOME'), '.github-backup.conf')
 
 def main():
-    global IsAuthorized
+    global IS_AUTHORIZED
     logging.basicConfig(level=logging.INFO)
 
 
@@ -113,15 +113,15 @@ def main():
         else:
             account = gh.get_user(args.login_or_token)
 
-    IsAuthorized = isinstance(account, github.AuthenticatedUser.AuthenticatedUser)
-    assert not (bool(config.get('password', None)) ^ IsAuthorized), account
+    IS_AUTHORIZED = isinstance(account, github.AuthenticatedUser.AuthenticatedUser)
+    assert not (bool(config.get('password', None)) ^ IS_AUTHORIZED), account
 
-    if args.include_keys and not IsAuthorized:
+    if args.include_keys and not IS_AUTHORIZED:
         LOGGER.info("Cannot backup keys with unauthenticated account, ignoring...")
         args.include_keys = False
 
     filters = {}
-    if IsAuthorized:
+    if IS_AUTHORIZED:
         # Get all repos
         filters = {
             'affiliation': ','.join(args.affiliation),
@@ -259,7 +259,7 @@ def process_account(gh, account, args):
     with codecs.open(account_file, 'w', encoding='utf-8') as f:
         json_dump(account.raw_data, f)
 
-    if IsAuthorized:
+    if IS_AUTHORIZED:
         emails_file = os.path.join(dir, 'emails.json')
         with codecs.open(emails_file, 'w', encoding='utf-8') as f:
             json_dump(list(account.get_emails()), f)
@@ -326,7 +326,7 @@ class RepositoryBackup(object):
 
         if self.is_gist:
             url = repo.git_pull_url
-        elif args.type == 'http' or not IsAuthorized:
+        elif args.type == 'http' or not IS_AUTHORIZED:
             url = repo.clone_url
         elif args.type == 'ssh':
             url = repo.ssh_url

--- a/github-backup.py
+++ b/github-backup.py
@@ -46,6 +46,7 @@ def main():
         args.include_watched = True
         args.include_followers = True
         args.include_following = True
+        args.include_wiki = True
     if args.include_starred or args.include_watched or args.include_followers \
        or args.include_following:
         args.account = True
@@ -141,6 +142,10 @@ def init_parser():
                         action='store_true',
                         dest='include_following',
                         help='include JSON output of following users in backup')
+    parser.add_argument('--wikis',
+                        action='store_true',
+                        dest='include_wiki',
+                        help='include wiki clone in backup')
 
     return parser
 
@@ -217,6 +222,11 @@ def clone_repo(repo, dir, args):
     git_args = [url, os.path.basename(dir)]
     if args.mirror:
         git_args.insert(0, '--mirror')
+
+    if args.include_wiki and repo.has_wiki:
+        git_wiki_args = git_args.copy()
+        git_wiki_args[0] = url.replace('.git', '.wiki.git')
+        git("clone", git_wiki_args, args.git, os.path.join(os.path.dirname(dir), 'wiki'))
 
     git("clone", git_args, args.git, os.path.dirname(dir))
 

--- a/github-backup.py
+++ b/github-backup.py
@@ -8,11 +8,11 @@ Created: Fri Jun 15 2012
 """
 
 
-from github import Github
 from argparse import ArgumentParser
 import subprocess
 import os, os.path
 import logging
+import github
 
 LOGGER = logging.getLogger('github-backup')
 
@@ -27,6 +27,7 @@ def main():
         LOGGER.setLevel(logging.WARN)
     elif args.debug:
         LOGGER.setLevel(logging.DEBUG)
+        github.enable_console_debug_logging()
 
     # Process args
     if args.quiet:
@@ -40,7 +41,7 @@ def main():
     if args.password:
         config['password'] = args.password
 
-    gh = Github(**config)
+    gh = github.Github(**config)
 
     # Check that backup dir exists
     if not os.path.exists(args.backupdir):

--- a/github-backup.py
+++ b/github-backup.py
@@ -252,10 +252,7 @@ def process_account(gh, account, args):
         LOGGER.info("    Getting issues for user %s", account.login)
         issues = []
         for filter in filters:
-            if IsAuthorized:
-                _issues = account.get_issues(state='all', filter=filter)
-            else:
-                _issues = gh.search_issues('', author=account.login, type='issue')
+            _issues = gh.search_issues('', author=account.login, type='issue')
             issues = itertools.chain(issues, _issues)
 
         RepositoryBackup._backup_issues(issues, args, dir)
@@ -264,10 +261,7 @@ def process_account(gh, account, args):
         LOGGER.info("    Getting pull requests for user %s", account.login)
         issues = []
         for filter in filters:
-            if IsAuthorized:
-                _issues = account.get_issues(state='all', filter=filter)
-            else:
-                _issues = gh.search_issues('', author=account.login, type='pr')
+            _issues = gh.search_issues('', author=account.login, type='pr')
             issues = itertools.chain(issues, _issues)
 
         RepositoryBackup._backup_pulls(issues, args, dir)
@@ -404,14 +398,7 @@ class RepositoryBackup(object):
         for issue in issues:
             project = os.path.basename(os.path.dirname(os.path.dirname(issue.url)))
             if isinstance(issue, github.Issue.Issue):
-                try:
-                    if issue.pull_request:
-                        issue = issue.as_pull_request()
-                    else:
-                        continue
-                except github.UnknownObjectException, e:
-                    LOGGER.info("     * %s[%s]: No associated pull request", project, issue.number)
-                    continue
+                issue = issue.as_pull_request()
             issue_data = issue.raw_data.copy()
             LOGGER.info("     * %s[%s]: %s", project, issue.number, issue.title)
             if args.include_pull_comments and issue.comments:

--- a/github-backup.py
+++ b/github-backup.py
@@ -3,6 +3,7 @@
 """
 Authors: Anthony Gargiulo (anthony@agargiulo.com)
          Steffen Vogel (post@steffenvogel.de)
+         Glenn Washburn (development@efficientek.com)
 
 Created: Fri Jun 15 2012
 """

--- a/github-backup.py
+++ b/github-backup.py
@@ -91,12 +91,13 @@ def main():
     if args.account:
         process_account(gh, account, args)
 
-    repos = account.get_repos(**filters)
-    for repo in repos:
-        if args.skip_forks and repo.fork:
-            continue
+    if not args.skip_repos:
+        repos = account.get_repos(**filters)
+        for repo in repos:
+            if args.skip_forks and repo.fork:
+                continue
 
-        process_repo(repo, args)
+            process_repo(repo, args)
 
 def init_parser():
     """Set up the argument parser."""
@@ -111,6 +112,7 @@ def init_parser():
     parser.add_argument("-q", "--quiet", help="Only show errors", action="store_true")
     parser.add_argument("-m", "--mirror", help="Create a bare mirror", action="store_true")
     parser.add_argument("-f", "--skip-forks", help="Skip forks", action="store_true")
+    parser.add_argument("--skip-repos", help="Skip backing up repositories", action="store_true")
     parser.add_argument("-g", "--git", nargs="+", help="Pass extra arguments to git", type=list, default=[], metavar="ARGS")
     parser.add_argument("-t", "--type", help="Select the protocol for cloning", choices=['git', 'http', 'ssh'], default='ssh')
     parser.add_argument("-s", "--suffix", help="Add suffix to repository directory names", default="")

--- a/github-backup.py
+++ b/github-backup.py
@@ -187,9 +187,11 @@ def process_account(gh, account, args):
 def process_repo(repo, args):
     LOGGER.info("Processing repo: %s", repo.full_name)
 
-    dir = args.backupdir + '/' + args.prefix + repo.name + args.suffix
-    config = "%s/%s" % (dir, "config" if args.mirror else ".git/config")
+    dir = os.path.join(args.backupdir, 'repositories', args.prefix + repo.name + args.suffix, 'repository')
+    config = os.path.join(dir, "config" if args.mirror else ".git/config")
 
+    if not os.access(os.path.dirname(dir), os.F_OK):
+        mkdir_p(os.path.dirname(dir))
     if not os.access(config, os.F_OK):
         LOGGER.info("Repo doesn't exists, lets clone it")
         clone_repo(repo, dir, args)
@@ -216,7 +218,7 @@ def clone_repo(repo, dir, args):
     if args.mirror:
         git_args.insert(0, '--mirror')
 
-    git("clone", git_args, args.git, args.backupdir)
+    git("clone", git_args, args.git, os.path.dirname(dir))
 
 
 def update_repo(repo, dir, args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+requests
 PyGitHub


### PR DESCRIPTION
This fixes #21 and adds a bunch of new features.  It also changes the directory structure of the backup. Some changes:

1.  By default log progress messages
1. Debug logging now enables PyGithub debug output, like request logging
1. Unauthenticated access is supported again.
1. Allow backing up a user other than the one you are authenticated as. This helps to bypass guthub anonymous api usage limits
1. Option to download account data (still more account data that could be retrieved)
1. Option to download the repository wiki, issues, pull requests, and assets
1. Option to backup account gists
1. Option to save ssh keys
1. If `-p` is given with no argument, then search for config file (`~/.github-backup.conf`) to get `APITOKEN` or `PASSWORD` keys to use for the password, and if no config file then to prompt the user for a password.  This way passwords won't show up in the history or `ps` output.

This doesn't backup everything, so there's more to add, but it goes a long way. If you'd rather have this broken up into several commits let me know.
