### PR TITLE
fix GitHub token not used when not password arg is not present

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -71,14 +71,13 @@ def main():
     args.backupdir = args.backupdir.rstrip("/")
 
     # Make the connection to Github here.
-    config = {}
+    config = {'login_or_token': args.login_or_token}
     if args.password == False:
         # no password option given, continue unauthenticated
         # unauthenticated users can only use http git method
         args.type = 'http'
     elif args.password == None:
         # password option given, but no password value given
-        config = {'login_or_token': args.login_or_token}
         if os.path.isfile(CONFFILE):
             cfg = ConfigParser()
             cfg.read(CONFFILE)
@@ -91,7 +90,6 @@ def main():
             if password:
                 config['password'] = password
     else:
-        config = {'login_or_token': args.login_or_token}
         config['password'] = args.password
 
     LOGGER.debug("Github config: %r", config)


### PR DESCRIPTION
this should fix #42 and #47

when I ran `github-backup` like this:
`$ github-backup ghp_TOKEN . --all -u bb1950328`
I got a `github.GithubException.RateLimitExceededException: 403` pretty fast. After applying the changes it worked.