### PR TITLE
Fixing usage for different cases

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -10,6 +10,7 @@ Created: Fri Jun 15 2012
 
 
 import os
+import re
 import errno
 import codecs
 import json
@@ -337,7 +338,15 @@ class RepositoryBackup(object):
         elif args.type == 'git':
             url = repo.git_url
         elif args.type == 'http' or not IS_AUTHORIZED:
-            url = repo.clone_url
+            if re.match('^ghp_.+$', args.login_or_token):
+                url = re.sub('^https://', f'https://{args.login_or_token}:x-auth-basic@', repo.clone_url)
+            elif args.password:
+                if args.username:
+                    url = re.sub('^https://', f'https://{args.username}:{args.password}@', repo.clone_url)
+                else:
+                    url = re.sub('^https://', f'https://{args.login_or_token}:{args.password}@', repo.clone_url)
+            else:
+                url = repo.clone_url
         self.url = url
 
         self.wiki_url = None


### PR DESCRIPTION
I get different exceptions:
1. if I try to give access_token instead login_or_token:
```
$ github-backup access_token dir_name --organization org_name --mirror
Traceback (most recent call last):
  File "/home/q/Downloads/sputnik_work/github.com/./env/bin/github-backup", line 11, in <module>
    load_entry_point('GitHub-Backup==0.1', 'console_scripts', 'github-backup')()
  File "/home/q/Downloads/sputnik_work/github.com/env/lib/python3.9/site-packages/github_backup/github_backup.py", line 108, in main
    account = gh.get_organization(args.login_or_token)
  File "/home/q/Downloads/sputnik_work/github.com/env/lib/python3.9/site-packages/github/MainClass.py", line 296, in get_organization
    headers, data = self.__requester.requestJsonAndCheck("GET", f"/orgs/{login}")
  File "/home/q/Downloads/sputnik_work/github.com/env/lib/python3.9/site-packages/github/Requester.py", line 353, in requestJsonAndCheck
    return self.__check(
  File "/home/q/Downloads/sputnik_work/github.com/env/lib/python3.9/site-packages/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/reference/orgs#get-an-organization"}
```
2. if I try to give access_token as password:
```
$ github-backup org_name dir_name --organization org_name --password
Enter password for org_name:
Traceback (most recent call last):
  File "/home/q/Downloads/sputnik_work/github.com/./env/bin/github-backup", line 11, in <module>
    load_entry_point('GitHub-Backup==0.1', 'console_scripts', 'github-backup')()
  File "/home/q/Downloads/sputnik_work/github.com/env/lib/python3.9/site-packages/github_backup/github_backup.py", line 118, in main
    assert not (bool(config.get('password', None)) ^ IS_AUTHORIZED), account
AssertionError: Organization(login="org_name")
```
This PR should to fix this behaviour.