### PR TITLE
Import ConfigParser instead of SafeConfigParser

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -20,7 +20,7 @@ import getpass
 from datetime import datetime, timezone
 import time
 try: #PY3
-    from configparser import SafeConfigParser as ConfigParser
+    from configparser import ConfigParser
 except ImportError:
     from ConfigParser import SafeConfigParser as ConfigParser
 from argparse import ArgumentParser


### PR DESCRIPTION
`SafeConfigParser` was renamed to `ConfigParser` a long time ago but still had an alias. In Python 3.12, this alias was removed causing this script to not run. This PR fixes this by using `ConfigParser` directly.